### PR TITLE
Add STEP/IGES File Loading to the Example

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,9 @@
 				Thickness:
 				<input type="range" min="5" max="100" value="30" onchange="changeSliderThickness(this.value)" />
 			</div>
+
+			<input id="step-file" name="step-file" type="file" accept=".iges,.step,.igs,.stp" style="display:none;"/>
+			<label for="step-file" title="Load STEP from File" style="border: 1px solid gray;background-color: #ffffff;padding: 1.5px 5px 2px 5px">Load STEP/IGES 📁</label>
 		</div>
 		<div id="viewport">
 		</div>


### PR DESCRIPTION
This addition to the example demonstrates how to use Emscripten's `FS` (File System) to import both .STEP and .IGES CAD files into opencascade.js

Hopefully this will save people some time when building Online CAD File Viewers.

Thank you @donalffons for this awesome library!

You can test out a live version of this PR here:
https://zalo.github.io/opencascade.js-examples/